### PR TITLE
fix(azure): make initAzureRepo idempotent; test: align Azure integrat…

### DIFF
--- a/Sources/BackupCore/AzureBlob.swift
+++ b/Sources/BackupCore/AzureBlob.swift
@@ -274,9 +274,9 @@ public extension BackupManager {
     /// Initialize a cloud repo by writing a config.json at the container root.
     func initAzureRepo(containerSASURL: URL) throws {
         let client = AzureBlobClient(containerSASURL: containerSASURL)
-        // If already exists, throw
+    // If already exists, do nothing (idempotent)
         let exists = (try? client.exists(blobPath: "config.json")) ?? false
-        if exists { throw BackupError.repoAlreadyExists(containerSASURL) }
+    if exists { return }
         let cfg = RepoConfig(version: 1, createdAt: Date())
         let data = try JSON.encoder.encode(cfg)
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("bckp-config.json")

--- a/Tests/BackupCoreTests/AzureIntegrationTests.swift
+++ b/Tests/BackupCoreTests/AzureIntegrationTests.swift
@@ -50,15 +50,16 @@ final class AzureIntegrationTests: XCTestCase {
         let items = try manager.listSnapshotsInAzure(containerSASURL: sasURL)
         XCTAssertTrue(items.contains(where: { $0.id == snap.id }), "Uploaded snapshot should be listed")
 
-        // Restore to a temp directory and verify contents
+    // Restore to a temp directory and verify contents
         let restoreDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("bckp-azure-int-dst-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: restoreDir, withIntermediateDirectories: true)
         try manager.restoreFromAzure(snapshotId: snap.id, containerSASURL: sasURL, to: restoreDir, concurrency: 2)
 
         // Validate restored files
-        let restoredFile1 = restoreDir.appendingPathComponent("file1.txt")
-        let restoredFile2 = restoreDir.appendingPathComponent("sub/file2.txt")
+    let root = src.lastPathComponent
+    let restoredFile1 = restoreDir.appendingPathComponent("\(root)/file1.txt")
+    let restoredFile2 = restoreDir.appendingPathComponent("\(root)/sub/file2.txt")
         XCTAssertTrue(FileManager.default.fileExists(atPath: restoredFile1.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: restoredFile2.path))
         let c1 = try String(contentsOf: restoredFile1, encoding: .utf8)


### PR DESCRIPTION
…ion restore layout with local semantics\n\n- init: return early if config.json exists, safe to re-run\n- tests: expect restored files under <dst>/<src.lastPathComponent>/...\n- all tests pass locally