### PR TITLE
cli: print snapshot sizes as raw bytes (no 'B'); update help to state…

### DIFF
--- a/Sources/bckp-cli/main.swift
+++ b/Sources/bckp-cli/main.swift
@@ -209,7 +209,7 @@ extension Bckp {
                 print(String(format: "[%.0f%%] %d/%d files (%@/%@) %@", percent, p.processedFiles, p.totalFiles, processed, total, cur))
             } : nil)
             let sizeStr = "\(snap.totalBytes)"
-            print("Created cloud snapshot: \(snap.id) | files: \(snap.totalFiles) | size: \(sizeStr)")
+            print("Created cloud snapshot: \(snap.id) | files: \(snap.totalFiles) | size: \(snap.totalBytes)")
         }
     }
 


### PR DESCRIPTION
… sizes are in bytes for local and Azure lists