### PR TITLE
gui: remove 'B' suffix from snapshot size label; show raw bytes to ma…

### DIFF
--- a/Sources/bckp-app/ContentView.swift
+++ b/Sources/bckp-app/ContentView.swift
@@ -474,6 +474,7 @@ private struct SourceRow: View {
 /// Render a snapshot row showing ID (monospaced) and file count.
 private struct SnapshotRow: View {
     let item: SnapshotListItem
+    private static func formatBytes(_ v: Int64) -> String { String(v) }
     var body: some View {
         HStack(alignment: .firstTextBaseline) {
             VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
…tch CLI