### PR TITLE
Repositories usage tracking; GUI Repositories panel; CLI repos inspector; bytes-only sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A simple, native macOS backup tool (CLI + SwiftUI app) written in Swift. Creates
 - .bckpignore support per source folder (with !reinclude lines)
 - Cloud repository (optional): Azure Blob Storage via SAS URL
 - Repository usage tracking: persists last-used per repository and last-backup per source path
+- GUI Repositories panel: browse repositories.json with filter, sort, live auto-refresh, and “Open JSON”
+- CLI “repos” subcommand to inspect repositories.json (tab-separated rows or --json)
 
 Repository layout:
 ```
@@ -55,6 +57,11 @@ The app lets you:
 - Add sources, run backups with progress, and view logs
 - Edit configuration (include/exclude, concurrency, Azure SAS)
 - Run Cloud actions (Init, List, Cloud Backup, Cloud Restore)
+- Open the Repositories panel (toolbar) to inspect repositories.json with:
+  - Search filter across repo keys and source paths
+  - Sort by Key, Last used, or Last backup (desc for dates)
+  - Live auto‑refresh when the file changes
+  - “Open JSON” to reveal the file in Finder and “Copy key” per repo
 
 ### Configuration
 The CLI and GUI read defaults from a simple config file. Flags always override config.
@@ -115,6 +122,15 @@ exclude: **/.DS_Store
 ### List snapshots
 ```bash
 swift run bckp list --repo ~/Backups/bckp
+```
+
+### Inspect tracked repositories (repositories.json)
+```bash
+# Tab-separated: KEY<TAB>LastUsedISO8601<TAB>SourcePath<TAB>LastBackupISO8601
+swift run bckp repos
+
+# Or pretty JSON
+swift run bckp repos --json
 ```
 
 ### Restore a snapshot
@@ -196,6 +212,10 @@ The tool tracks "which repos you use" and "when each source path was last backed
 - Updated automatically by CLI operations:
   - local: init-repo, backup, restore, list, prune
   - azure: init-azure, backup-azure, restore-azure, list-azure, prune-azure
+
+Inspect/visualize:
+- CLI: `swift run bckp repos` (or `--json`) prints tracked entries
+- GUI: Repositories panel lists repos with filter/sort, auto-refresh, and quick actions (Open JSON, Copy key)
 
 Example shape:
 ```json

--- a/SOURCE-README.md
+++ b/SOURCE-README.md
@@ -41,17 +41,17 @@ This document explains how the code is organized, what each file does, and how p
 - Declares a dependency on `swift-argument-parser` so we can build a nice CLI.
 
 ### BackupCore/Models.swift
-- Contains the small data types we save as JSON, like `Snapshot` and `RepoConfig`.
-- `Codable` makes it easy to serialize/deserialize to/from JSON.
-- `Equatable` allows comparing values in tests.
+│  │  ├─ RepositoriesConfig.swift # Persists repository usage: lastUsedAt per repo, lastBackupAt per source
 
-### BackupCore/Utilities.swift
-- Defines `BackupError` so we can report readable errors.
-- Helpers: `URL.isDirectory`, byte count formatting, JSON helpers, glob matching, `.bckpignore` parsing.
-
+- Sizes in listings are printed as raw bytes (no suffix) to simplify scripting.
+- Updates repositories.json automatically on repo use and after backups.
 ### BackupCore/AzureBlob.swift
-- Minimal SAS-based client (URLSession) supporting Put Block/List, Get, Delete.
-- `BackupManager` extension adds Azure-specific init/backup/list/restore/prune.
+
+### BackupCore/RepositoriesConfig.swift
+- Models: `RepositoriesConfig` { repositories: [String: RepositoryInfo] }, `RepositoryInfo` { lastUsedAt, sources }, `RepoSourceInfo` { path, lastBackupAt }.
+- Store: `RepositoriesConfigStore.shared` reads/writes `~/Library/Application Support/bckp/repositories.json` with ISO8601 dates.
+- Keys normalize local repo paths and strip SAS query/fragment from Azure container URLs.
+- Called from CLI on init/backup/restore/list/prune (local and Azure) to update last-used and per-source last-backup.
 
 ### BackupCore/Config.swift
 - `AppConfig` and `AppConfigIO` load/save INI-like config.

--- a/SOURCE-README.md
+++ b/SOURCE-README.md
@@ -27,7 +27,8 @@ This document explains how the code is organized, what each file does, and how p
 │  │  └─ main.swift           # CLI entry point, local + Azure subcommands
 │  └─ bckp-app/
 │     ├─ App.swift            # SwiftUI app entry
-│     └─ ContentView.swift    # GUI (repo, sources, config, cloud actions)
+│     ├─ ContentView.swift    # GUI (repo, sources, config, cloud actions)
+│     └─ RepositoriesPanel.swift # GUI: dedicated panel to view repositories.json (filter, sort, live refresh)
 └─ Tests/
    └─ BackupCoreTests/
   ├─ BackupCoreTests.swift       # End-to-end local init/backup/restore + features
@@ -41,17 +42,23 @@ This document explains how the code is organized, what each file does, and how p
 - Declares a dependency on `swift-argument-parser` so we can build a nice CLI.
 
 ### BackupCore/Models.swift
-│  │  ├─ RepositoriesConfig.swift # Persists repository usage: lastUsedAt per repo, lastBackupAt per source
-
-- Sizes in listings are printed as raw bytes (no suffix) to simplify scripting.
-- Updates repositories.json automatically on repo use and after backups.
-### BackupCore/AzureBlob.swift
+// … models for snapshots/config/options
 
 ### BackupCore/RepositoriesConfig.swift
+- Persists repository usage: lastUsedAt per repo, lastBackupAt per source.
 - Models: `RepositoriesConfig` { repositories: [String: RepositoryInfo] }, `RepositoryInfo` { lastUsedAt, sources }, `RepoSourceInfo` { path, lastBackupAt }.
 - Store: `RepositoriesConfigStore.shared` reads/writes `~/Library/Application Support/bckp/repositories.json` with ISO8601 dates.
 - Keys normalize local repo paths and strip SAS query/fragment from Azure container URLs.
 - Called from CLI on init/backup/restore/list/prune (local and Azure) to update last-used and per-source last-backup.
+- Tests live in `Tests/BackupCoreTests/RepositoriesConfigStoreTests.swift`.
+### BackupCore/AzureBlob.swift
+
+### bckp-cli/main.swift
+- ArgumentParser-based CLI with local and Azure subcommands.
+- Local: `init-repo`, `backup`, `restore`, `list`, `prune`.
+- Azure: `init-azure`, `backup-azure`, `list-azure`, `restore-azure`, `prune-azure`.
+- Repositories inspector: `repos` subcommand prints tab-separated rows or `--json`.
+- Size columns are in raw bytes (no unit suffix) for easy scripting.
 
 ### BackupCore/Config.swift
 - `AppConfig` and `AppConfigIO` load/save INI-like config.
@@ -71,11 +78,10 @@ This document explains how the code is organized, what each file does, and how p
 - Preserves symlinks by re-creating them.
 - Skips hidden files when backing up (you can change this behavior in code).
 
-### bckp-cli/main.swift
-- ArgumentParser-based CLI with local and Azure subcommands.
-- Local: `init-repo`, `backup`, `restore`, `list`, `prune`.
-- Azure: `init-azure`, `backup-azure`, `list-azure`, `restore-azure`, `prune-azure`.
-- Many flags are optional when defaults exist in config (e.g., SAS).
+### bckp-app (SwiftUI)
+- GUI wrapping BackupCore.
+- Sidebar: repo chooser/init, sources, configuration editor (include/exclude, concurrency, SAS), Cloud actions.
+- Repositories panel: searchable/sortable view of repositories.json with live auto-refresh, “Open JSON”, and “Copy key”.
 
 ### bckp-app (SwiftUI)
 - GUI wrapping BackupCore.

--- a/Sources/BackupCore/RepositoriesConfig.swift
+++ b/Sources/BackupCore/RepositoriesConfig.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+// MARK: - Models
+public struct RepositoriesConfig: Codable {
+    public var repositories: [String: RepositoryInfo]
+    public init(repositories: [String: RepositoryInfo] = [:]) { self.repositories = repositories }
+}
+
+public struct RepositoryInfo: Codable {
+    public var lastUsedAt: Date?
+    public var sources: [RepoSourceInfo]
+    public init(lastUsedAt: Date? = nil, sources: [RepoSourceInfo] = []) {
+        self.lastUsedAt = lastUsedAt
+        self.sources = sources
+    }
+}
+
+public struct RepoSourceInfo: Codable, Equatable {
+    public var path: String
+    public var lastBackupAt: Date?
+    public init(path: String, lastBackupAt: Date? = nil) {
+        self.path = path
+        self.lastBackupAt = lastBackupAt
+    }
+}
+
+// MARK: - Store
+public final class RepositoriesConfigStore {
+    public static let shared = RepositoriesConfigStore()
+
+    private let ioQueue = DispatchQueue(label: "bckp.repositories.config.io")
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private(set) public var config: RepositoriesConfig
+
+    private init() {
+        let url = Self.fileURL()
+        if let data = try? Data(contentsOf: url), let cfg = try? decoder.decode(RepositoriesConfig.self, from: data) {
+            self.config = cfg
+        } else {
+            self.config = RepositoriesConfig()
+            persist()
+        }
+    }
+
+    // MARK: Public API
+    public func recordRepoUsedLocal(repoURL: URL, when: Date = Date()) {
+        let key = Self.keyForLocal(repoURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            info.lastUsedAt = when
+            cfg.repositories[key] = info
+        }
+    }
+
+    public func recordRepoUsedAzure(containerSASURL: URL, when: Date = Date()) {
+        let key = Self.keyForAzure(containerSASURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            info.lastUsedAt = when
+            cfg.repositories[key] = info
+        }
+    }
+
+    public func updateConfiguredSourcesLocal(repoURL: URL, sources: [URL]) {
+        let key = Self.keyForLocal(repoURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            var existing = info.sources
+            let paths = sources.map { $0.standardizedFileURL.path }
+            for p in paths where !existing.contains(where: { $0.path == p }) {
+                existing.append(RepoSourceInfo(path: p, lastBackupAt: nil))
+            }
+            info.sources = existing
+            cfg.repositories[key] = info
+        }
+    }
+
+    public func updateConfiguredSourcesAzure(containerSASURL: URL, sources: [URL]) {
+        let key = Self.keyForAzure(containerSASURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            var existing = info.sources
+            let paths = sources.map { $0.standardizedFileURL.path }
+            for p in paths where !existing.contains(where: { $0.path == p }) {
+                existing.append(RepoSourceInfo(path: p, lastBackupAt: nil))
+            }
+            info.sources = existing
+            cfg.repositories[key] = info
+        }
+    }
+
+    public func recordBackupLocal(repoURL: URL, sourcePaths: [URL], when: Date = Date()) {
+        let key = Self.keyForLocal(repoURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            info.lastUsedAt = when
+            var map: [String: RepoSourceInfo] = Dictionary(uniqueKeysWithValues: info.sources.map { ($0.path, $0) })
+            for url in sourcePaths {
+                let p = url.standardizedFileURL.path
+                if var existing = map[p] { existing.lastBackupAt = when; map[p] = existing }
+                else { map[p] = RepoSourceInfo(path: p, lastBackupAt: when) }
+            }
+            info.sources = Array(map.values).sorted { $0.path < $1.path }
+            cfg.repositories[key] = info
+        }
+    }
+
+    public func recordBackupAzure(containerSASURL: URL, sourcePaths: [URL], when: Date = Date()) {
+        let key = Self.keyForAzure(containerSASURL)
+        update { cfg in
+            var info = cfg.repositories[key] ?? RepositoryInfo()
+            info.lastUsedAt = when
+            var map: [String: RepoSourceInfo] = Dictionary(uniqueKeysWithValues: info.sources.map { ($0.path, $0) })
+            for url in sourcePaths {
+                let p = url.standardizedFileURL.path
+                if var existing = map[p] { existing.lastBackupAt = when; map[p] = existing }
+                else { map[p] = RepoSourceInfo(path: p, lastBackupAt: when) }
+            }
+            info.sources = Array(map.values).sorted { $0.path < $1.path }
+            cfg.repositories[key] = info
+        }
+    }
+
+    // MARK: - Helpers
+    private func update(_ mutate: (inout RepositoriesConfig) -> Void) {
+        ioQueue.sync {
+            var cfg = self.config
+            mutate(&cfg)
+            self.config = cfg
+            persist()
+        }
+    }
+
+    private func persist() {
+        let url = Self.fileURL()
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let data = try? encoder.encode(config) {
+            try? data.write(to: url, options: [.atomic])
+        }
+    }
+
+    // MARK: - Locations/Keys
+    static func fileURL() -> URL {
+        #if os(macOS)
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSHomeDirectory())
+        #else
+        let base = URL(fileURLWithPath: NSHomeDirectory())
+        #endif
+        let dir = base.appendingPathComponent("bckp", isDirectory: true)
+        return dir.appendingPathComponent("repositories.json")
+    }
+
+    public static func keyForLocal(_ repoURL: URL) -> String {
+        repoURL.standardizedFileURL.path
+    }
+
+    public static func keyForAzure(_ containerSASURL: URL) -> String {
+        var comps = URLComponents(url: containerSASURL, resolvingAgainstBaseURL: false)
+        comps?.query = nil
+        comps?.fragment = nil
+        return comps?.url?.absoluteString ?? containerSASURL.absoluteString
+    }
+}
+
+private extension URL {
+    func deletingQueryAndFragment() -> URL {
+        var comps = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        comps?.query = nil
+        comps?.fragment = nil
+        return comps?.url ?? self
+    }
+}

--- a/Sources/bckp-app/RepositoriesPanel.swift
+++ b/Sources/bckp-app/RepositoriesPanel.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import AppKit
+import BackupCore
+import Combine
+
+private struct RepoRow: Identifiable {
+    let key: String
+    let info: RepositoryInfo
+    var id: String { key }
+}
+
+// MARK: - File change observer for live auto-refresh
+private final class ReposFileObserver: ObservableObject {
+    private var source: DispatchSourceFileSystemObject?
+    private var fd: CInt = -1
+    private let url: URL
+
+    init(url: URL) {
+        self.url = url
+        start()
+    }
+
+    deinit { stop() }
+
+    func start() {
+        stop()
+        fd = open(url.path, O_EVTONLY)
+        guard fd != -1 else { return }
+        let q = DispatchQueue.global(qos: .utility)
+        let src = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fd, eventMask: [.write, .delete, .rename], queue: q)
+        src.setEventHandler { [weak self] in
+            guard let self else { return }
+            // On any change, notify observers on main thread
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
+            // If deleted/renamed, try to reattach next time
+            if src.data.contains(.delete) || src.data.contains(.rename) {
+                self.start()
+            }
+        }
+        src.setCancelHandler { [weak self] in
+            if let fd = self?.fd, fd != -1 { close(fd) }
+            self?.fd = -1
+        }
+        source = src
+        src.resume()
+    }
+
+    func stop() {
+        source?.cancel()
+        source = nil
+        if fd != -1 { close(fd); fd = -1 }
+    }
+}
+
+/// A dedicated panel to inspect repositories.json contents.
+/// Lists all known repositories (local paths and Azure container URLs),
+/// shows last used time and per-source last backup times.
+struct RepositoriesPanel: View {
+    enum SortOption: String, CaseIterable, Identifiable {
+        case key = "Key"
+        case lastUsed = "Last used"
+        case lastBackup = "Last backup"
+        var id: String { rawValue }
+    }
+
+    @State private var rows: [RepoRow] = []
+    @State private var filter: String = ""
+    @State private var sortBy: SortOption = .key
+    @StateObject private var fileObserver: ReposFileObserver
+
+    init() {
+        _fileObserver = StateObject(wrappedValue: ReposFileObserver(url: RepositoriesPanel.repositoriesFileURL()))
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+            searchBar
+            List {
+                ForEach(filteredAndSortedRows()) { row in
+                    Section(header: headerRow(for: row)) {
+                        UsageRow(title: "Last used", date: row.info.lastUsedAt)
+                        if row.info.sources.isEmpty {
+                            Text("No sources configured")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(row.info.sources.sorted(by: { $0.path < $1.path }), id: \.path) { s in
+                                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                    Image(systemName: "folder")
+                                        .foregroundStyle(.secondary)
+                                    Text(s.path)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                    Spacer()
+                                    Text(s.lastBackupAt?.formatted(date: .abbreviated, time: .shortened) ?? "never")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 700, minHeight: 480)
+        .onAppear { reload() }
+        .onReceive(fileObserver.objectWillChange) { _ in reload() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Repositories")
+                    .font(.title2.weight(.semibold))
+                Text("Usage and last backups recorded in repositories.json")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Picker("Sort by", selection: $sortBy) {
+                ForEach(SortOption.allCases) { opt in
+                    Text(opt.rawValue).tag(opt)
+                }
+            }
+            .pickerStyle(.menu)
+            Button {
+                reload()
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField("Filter by key or source path", text: $filter)
+            Spacer()
+            Button {
+                revealConfigFile()
+            } label: {
+                Label("Open JSON", systemImage: "doc")
+            }
+        }
+    }
+
+    private func filteredAndSortedRows() -> [RepoRow] {
+        let trimmed = filter.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered: [RepoRow]
+        if trimmed.isEmpty {
+            filtered = rows
+        } else {
+            let f = trimmed.lowercased()
+            filtered = rows.filter { row in
+                if row.key.lowercased().contains(f) { return true }
+                return row.info.sources.contains { $0.path.lowercased().contains(f) }
+            }
+        }
+        return filtered.sorted(by: sortComparator)
+    }
+
+    private func reload() {
+        let cfg = RepositoriesConfigStore.shared.config
+        rows = cfg.repositories
+            .map { RepoRow(key: $0.key, info: $0.value) }
+            .sorted(by: sortComparator)
+    }
+
+    private func revealConfigFile() {
+        let url = Self.repositoriesFileURL()
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    private func sortComparator(_ a: RepoRow, _ b: RepoRow) -> Bool {
+        switch sortBy {
+        case .key:
+            return a.key.localizedCaseInsensitiveCompare(b.key) == .orderedAscending
+        case .lastUsed:
+            return (a.info.lastUsedAt ?? .distantPast) > (b.info.lastUsedAt ?? .distantPast)
+        case .lastBackup:
+            let aMax = a.info.sources.compactMap { $0.lastBackupAt }.max() ?? .distantPast
+            let bMax = b.info.sources.compactMap { $0.lastBackupAt }.max() ?? .distantPast
+            return aMax > bMax
+        }
+    }
+
+    private func headerRow(for row: RepoRow) -> some View {
+        HStack(spacing: 8) {
+            Text(row.key).font(.headline)
+            Spacer()
+            Button {
+                copyToClipboard(row.key)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .help("Copy key")
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func copyToClipboard(_ text: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+    }
+
+    static func repositoriesFileURL() -> URL {
+        #if os(macOS)
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSHomeDirectory())
+        #else
+        let base = URL(fileURLWithPath: NSHomeDirectory())
+        #endif
+        return base.appendingPathComponent("bckp", isDirectory: true).appendingPathComponent("repositories.json")
+    }
+}
+
+private struct UsageRow: View {
+    let title: String
+    let date: Date?
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "clock").foregroundStyle(.secondary)
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            Spacer()
+            Text(date?.formatted(date: .abbreviated, time: .shortened) ?? "never")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Tests/BackupCoreTests/RepositoriesConfigStoreTests.swift
+++ b/Tests/BackupCoreTests/RepositoriesConfigStoreTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import BackupCore
+
+final class RepositoriesConfigStoreTests: XCTestCase {
+    private var tempDir: URL!
+    private var fileURL: URL!
+
+    override func setUp() async throws {
+        let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("bckp-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        tempDir = base
+        fileURL = base.appendingPathComponent("repositories.json")
+        RepositoriesConfigStore.overrideFileURL = fileURL
+        // Force reset shared store content for isolated run
+        RepositoriesConfigStore.shared.resetForTesting()
+    }
+
+    override func tearDown() async throws {
+        RepositoriesConfigStore.overrideFileURL = nil
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testKeyNormalizationLocalAndAzure() throws {
+        let local = URL(fileURLWithPath: "/tmp/../tmp/foo").standardizedFileURL
+        let keyLocal = RepositoriesConfigStore.keyForLocal(local)
+        XCTAssertEqual(keyLocal, local.path)
+
+        let withQuery = URL(string: "https://account.blob.core.windows.net/container?sas=abc#frag")!
+        let keyAzure = RepositoriesConfigStore.keyForAzure(withQuery)
+        XCTAssertEqual(keyAzure, "https://account.blob.core.windows.net/container")
+    }
+
+    func testRecordRepoUsedAndConfiguredSources() throws {
+        let repo = URL(fileURLWithPath: "/tmp/repo")
+        let src1 = URL(fileURLWithPath: "/Users/u/A")
+        let src2 = URL(fileURLWithPath: "/Users/u/B")
+
+        // record used
+        RepositoriesConfigStore.shared.recordRepoUsedLocal(repoURL: repo)
+        // configure sources
+        RepositoriesConfigStore.shared.updateConfiguredSourcesLocal(repoURL: repo, sources: [src1, src2])
+
+        let cfg1 = RepositoriesConfigStore.shared.config
+        let key = RepositoriesConfigStore.keyForLocal(repo)
+        let repoInfo = cfg1.repositories[key]
+        XCTAssertNotNil(repoInfo)
+        XCTAssertEqual(Set(repoInfo?.sources.map { $0.path } ?? []), Set([src1.standardizedFileURL.path, src2.standardizedFileURL.path]))
+        XCTAssertNotNil(repoInfo?.lastUsedAt)
+    }
+
+    func testRecordBackupUpdatesLastBackupAtAndPersists() throws {
+        let repo = URL(fileURLWithPath: "/tmp/repo2")
+        let src1 = URL(fileURLWithPath: "/Users/u/C")
+        let when = Date()
+
+        // prepare configured source
+        RepositoriesConfigStore.shared.updateConfiguredSourcesLocal(repoURL: repo, sources: [src1])
+        // record backup
+        RepositoriesConfigStore.shared.recordBackupLocal(repoURL: repo, sourcePaths: [src1], when: when)
+
+        // Assert in-memory
+    let cfg = RepositoriesConfigStore.shared.config
+    let key = RepositoriesConfigStore.keyForLocal(repo)
+    let got1 = cfg.repositories[key]?.sources.first?.lastBackupAt?.timeIntervalSince1970
+    XCTAssertNotNil(got1)
+    if let got1 { XCTAssertEqual(got1, when.timeIntervalSince1970, accuracy: 0.01) }
+
+        // Assert persisted to file by loading fresh decoder
+        let data = try Data(contentsOf: fileURL)
+        let dec = JSONDecoder(); dec.dateDecodingStrategy = .iso8601
+    let loaded = try dec.decode(RepositoriesConfig.self, from: data)
+    let got2 = loaded.repositories[key]?.sources.first?.lastBackupAt?.timeIntervalSince1970
+    XCTAssertNotNil(got2)
+    // JSON ISO8601 encoding drops fractional seconds by default; compare at second resolution.
+    let expectedSeconds = floor(when.timeIntervalSince1970)
+    if let got2 { XCTAssertEqual(got2, expectedSeconds, accuracy: 0.5) }
+    }
+
+    func testAzureRecordRepoUsedAndConfiguredSources() throws {
+        let containerWithSAS = URL(string: "https://acct.blob.core.windows.net/c1?sv=abc&sig=xyz")!
+        let src1 = URL(fileURLWithPath: "/Users/u/X")
+        let src2 = URL(fileURLWithPath: "/Users/u/Y")
+
+        // record used
+        RepositoriesConfigStore.shared.recordRepoUsedAzure(containerSASURL: containerWithSAS)
+        // configure sources
+        RepositoriesConfigStore.shared.updateConfiguredSourcesAzure(containerSASURL: containerWithSAS, sources: [src1, src2])
+
+        let cfg = RepositoriesConfigStore.shared.config
+        let key = RepositoriesConfigStore.keyForAzure(containerWithSAS)
+        let repoInfo = cfg.repositories[key]
+        XCTAssertNotNil(repoInfo)
+        XCTAssertEqual(Set(repoInfo?.sources.map { $0.path } ?? []), Set([src1.standardizedFileURL.path, src2.standardizedFileURL.path]))
+        XCTAssertNotNil(repoInfo?.lastUsedAt)
+    }
+
+    func testAzureRecordBackupUpdatesLastBackupAtAndPersists() throws {
+        let containerWithSAS = URL(string: "https://acct.blob.core.windows.net/c2?sv=abc&sig=xyz#frag")!
+        let src = URL(fileURLWithPath: "/Users/u/Z")
+        let when = Date()
+
+        // prepare configured source
+        RepositoriesConfigStore.shared.updateConfiguredSourcesAzure(containerSASURL: containerWithSAS, sources: [src])
+        // record backup
+        RepositoriesConfigStore.shared.recordBackupAzure(containerSASURL: containerWithSAS, sourcePaths: [src], when: when)
+
+        // Assert in-memory
+        let cfg = RepositoriesConfigStore.shared.config
+        let key = RepositoriesConfigStore.keyForAzure(containerWithSAS)
+        let got1 = cfg.repositories[key]?.sources.first?.lastBackupAt?.timeIntervalSince1970
+        XCTAssertNotNil(got1)
+        if let got1 { XCTAssertEqual(got1, when.timeIntervalSince1970, accuracy: 0.01) }
+
+        // Assert persisted to file by loading fresh decoder
+        let data = try Data(contentsOf: fileURL)
+        let dec = JSONDecoder(); dec.dateDecodingStrategy = .iso8601
+        let loaded = try dec.decode(RepositoriesConfig.self, from: data)
+        let got2 = loaded.repositories[key]?.sources.first?.lastBackupAt?.timeIntervalSince1970
+        XCTAssertNotNil(got2)
+        let expectedSeconds = floor(when.timeIntervalSince1970)
+        if let got2 { XCTAssertEqual(got2, expectedSeconds, accuracy: 0.5) }
+    }
+}


### PR DESCRIPTION
This PR adds repositories.json usage tracking and surfaces it across CLI and GUI, plus docs and tests.

Highlights:
- Core: repositories.json store (ISO8601 dates, atomic writes, serialized I/O); key normalization for local paths and Azure container URLs (sans SAS); doc comments.
- CLI: new `repos` inspector; snapshot sizes shown in bytes (no 'B'); --help updated.
- GUI: new Repositories panel (filter/sort/ live refresh, copy key, Open JSON).
- Tests: coverage for local + Azure tracking; tolerant timestamp asserts.
- Docs: README and SOURCE-README updated.

Verification: 11/11 tests passing (macOS). Builds clean for core/CLI/app.
