### PR TITLE
Fix release permissions (contents:write)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
Grant GITHUB_TOKEN contents: write so softprops/action-gh-release can create releases. This fixes 403 Resource not accessible by integration on tag push.