### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/smereczynski/bckp/security/code-scanning/2](https://github.com/smereczynski/bckp/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, caches dependencies, builds, and tests (all read-only operations), it only needs `contents: read` permission. The best way to fix this is to add the following block at the top level of the workflow (after the `name:` and before `on:`), which will apply to all jobs in the workflow. No changes to steps or other logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
