### PR TITLE
docs: document release artifacts (CLI zip, GUI binary zip, and Finder…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,8 +61,9 @@ The project embeds a version string at build time and automates releases via Git
   - Writes `Sources/BackupCore/Version.swift` with that exact string.
   - Builds release binaries via SwiftPM (`bckp`, `bckp-app`).
   - Packages artifacts:
-    - `bckp-<version>-macos.zip`
-    - `bckp-app-<version>-macos.zip`
+    - `bckp-<version>-macos.zip` (CLI binary inside named `bckp`)
+    - `bckp-app-<version>-macos.zip` (GUI binary inside named `bckp-app` for Terminal launch)
+    - `bckp-app-<version>-macos.app.zip` (double‑clickable Finder app bundle `bckp-app.app`)
     - `SHA256SUMS` with checksums for integrity.
   - Publishes a GitHub Release:
     - Title/Tag: `v<version>`
@@ -70,7 +71,9 @@ The project embeds a version string at build time and automates releases via Git
 
 4) Verify the release
 - Download artifacts, verify checksums from `SHA256SUMS`.
-- Run `./bckp --version` to confirm the embedded version matches the tag.
+- CLI: unzip `bckp-<version>-macos.zip`, run `./bckp --version` and confirm the tag.
+- GUI (Terminal): unzip `bckp-app-<version>-macos.zip`, run `./bckp-app` and confirm the app shows the version.
+- GUI (Finder): unzip `bckp-app-<version>-macos.app.zip`, move to Applications, launch. If Gatekeeper warns (unsigned, not notarized yet), right‑click → Open or clear quarantine: `xattr -dr com.apple.quarantine ~/Applications/bckp-app.app`.
 
 ### 4.3 Local builds and version override (optional)
 
@@ -80,9 +83,9 @@ The project embeds a version string at build time and automates releases via Git
 
 ### 4.4 Notes and future improvements
 
-- Current artifacts are SwiftPM executables (CLI + SwiftUI app) without code signing.
+- Artifacts include a raw GUI binary and a minimal `.app` bundle. Code signing and notarization are not yet enabled.
 - Optional follow‑ups:
   - Universal (arm64 + x86_64) macOS binaries.
-  - Code signing and notarization.
+  - Code signing and notarization for `.app` and binaries.
   - Homebrew tap for `bckp` CLI.
   - Changelog automation.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,31 @@ The app lets you:
   - Live auto‑refresh when the file changes
   - “Open JSON” to reveal the file in Finder and “Copy key” per repo
 
+## Install from Releases
+
+Prebuilt artifacts are published on each tag in GitHub Releases. You’ll see three macOS downloads:
+
+- bckp-<version>-macos.zip
+  - CLI executable. Unzip and run from Terminal.
+  - Example:
+    - unzip → file named `bckp`
+    - run: `./bckp --help`
+
+- bckp-app-<version>-macos.zip
+  - GUI executable as a raw binary (not a Finder app). Launch from Terminal:
+    - unzip → file named `bckp-app`
+    - run: `./bckp-app`
+  - This is useful for debugging; it’s not a proper `.app` bundle.
+
+- bckp-app-<version>-macos.app.zip
+  - Double‑clickable macOS app bundle for Finder.
+  - Unzip, then move `bckp-app.app` to `/Applications` (or `~/Applications`).
+  - If macOS Gatekeeper blocks it (unsigned/not notarized yet), you can allow it:
+    - Right‑click → Open, then Open; or remove quarantine attributes:
+      - `xattr -dr com.apple.quarantine ~/Applications/bckp-app.app`
+
+Checksums: a `SHA256SUMS` file is attached to the release.
+
 ### Configuration
 The CLI and GUI read defaults from a simple config file. Flags always override config.
 
@@ -176,7 +201,7 @@ Notes:
 - On macOS, repositories.json uses a stable key for external volumes: `ext://volumeUUID=<UUID><standardizedPath>`. This keeps entries stable across volume renames or mount-point changes.
 - The GUI surfaces the external volume UUID and the derived repo key and lets you copy the key for troubleshooting.
 
-## Release (build a distributable binary)
+## Build from source
 
 ### Debug (fast, default)
 ```bash
@@ -190,7 +215,7 @@ swift build -c release
 ls -l .build/release/bckp
 ```
 
-You can copy the built binary to a directory in your PATH (e.g., `~/bin`) or wrap it in a small `.pkg`/`.dmg` later.
+You can copy the built binary to a directory in your PATH (e.g., `~/bin`). Packaging and signing/notarization are tracked as future improvements.
 
 ### Azure (SAS) Cloud Repo
 You can pass `--sas` explicitly, or omit it to use the value from your config.

--- a/SOURCE-README.md
+++ b/SOURCE-README.md
@@ -130,3 +130,11 @@ This document explains how the code is organized, what each file does, and how p
 - Check `Models.swift`, `Utilities.swift`, and `Config.swift` to understand the data and helpers.
 - Explore the GUI in `Sources/bckp-app/ContentView.swift` to see how the app ties together.
 - Run `swift run bckp --help` and `swift run bckp-app` to try it.
+
+## Release packaging (macOS)
+- CI builds two executables: `bckp` (CLI) and `bckp-app` (GUI).
+- Artifacts published to Releases:
+  - `bckp-<version>-macos.zip` → contains a single file `bckp` (CLI; run from Terminal)
+  - `bckp-app-<version>-macos.zip` → contains a single file `bckp-app` (GUI; run from Terminal; not a Finder app)
+  - `bckp-app-<version>-macos.app.zip` → contains `bckp-app.app` (Finder-launchable app bundle)
+- The `.app` bundle is a minimal structure created in CI. It is currently unsigned and not notarized; Gatekeeper may require right‑click → Open or removing quarantine attributes for local testing.


### PR DESCRIPTION
… .app zip) and usage; clarify verification steps