### PR TITLE
CLI JSON: avoid escaping slashes; align encoders

### DIFF
--- a/Sources/bckp-cli/main.swift
+++ b/Sources/bckp-cli/main.swift
@@ -421,7 +421,7 @@ extension Bckp {
             }
             let cfg = RepositoriesConfigStore.shared.config
             if json {
-                let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys]; enc.dateEncodingStrategy = .iso8601
+                let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]; enc.dateEncodingStrategy = .iso8601
                 let data = try enc.encode(cfg)
                 if let s = String(data: data, encoding: .utf8) { print(s) }
                 return
@@ -612,7 +612,7 @@ extension Bckp {
     func run() throws {
             let disks = listExternalDiskIdentities()
             if json {
-                let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let enc = JSONEncoder(); enc.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
                 let data = try enc.encode(disks)
                 if let s = String(data: data, encoding: .utf8) { print(s) }
                 return


### PR DESCRIPTION
Fixes: JSON output escaping of slashes in CLI outputs.\n\nChanges:\n- Repos --json: JSONEncoder uses [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes] + ISO8601 dates.\n- Drives --json: same formatting to avoid escaped slashes in paths/URLs.\n\nVerification:\n- swift test: 26 tests passed, 2 skipped (env-guarded).\n- Manual check: 'bckp repos --json' shows https:// URLs without escaped slashes.\n\nNotes:\n- Store encoder already used withoutEscapingSlashes (macOS 12+); CLI now matches.\n\n